### PR TITLE
Changed to current stable redis

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -1,12 +1,11 @@
 #!/bin/bash
 mkdir /opt/redis
 mkdir /opt/redis/bin
-
 cd /opt/redis
-wget http://redis.googlecode.com/files/redis-2.6.13.tar.gz
-tar xzf redis-2.6.13.tar.gz
 
-cd redis-2.6.13
+wget http://download.redis.io/redis-stable.tar.gz
+tar xvzf redis-stable.tar.gz
+cd redis-stable
 make
 
 cp src/redis-server /opt/redis/bin/redis-server


### PR DESCRIPTION
Redis has moved to download.redis.io and they've
also been kind to create a redis-stable.tar.gz so
that we don't have to update the version.